### PR TITLE
Fix fetch-catalog when a cache directory does not exist and minor typo

### DIFF
--- a/stylus/refiner/README.md
+++ b/stylus/refiner/README.md
@@ -6,7 +6,7 @@ This tutorial assumes that the user has created an account on Civit AI and has g
 
 The first step is to fetch all of Civit AI's models via Civit's Rest API. This is saved in `stylus/cache/civit_catalog.json`. Run:
 ```
-python fetch_catalog.py.
+python fetch_catalog.py
 ```
 
 This should take 1-2 hours to complete. If not, the API server is congested.

--- a/stylus/refiner/fetch_catalog.py
+++ b/stylus/refiner/fetch_catalog.py
@@ -24,6 +24,10 @@ def fetch_civit_model_catalog(file_path: str = CATALOG_FILE_PATH) -> list:
     if os.path.exists(file_path):
         with open(file_path, 'r') as file:
             return json.load(file)
+            
+    cache_dir_path = os.path.join(os.path.dirname(cur_file_path), "cache")
+    if not os.path.exists(cache_dir_path):
+        os.makedirs(cache_dir_path)
 
     print('Downloading Civit AI Model Catalog...')
     request_url = f'{CIVIT_AI_URL}?{"&".join(CIVIT_AI_FILTERS)}'


### PR DESCRIPTION
What does this PR do?
---
This PR fixes an issue where the absence of a cache directory would cause an error by creating the cache directory if it doesn't exist. It also removes a minor typo in the readme, specifically the period in 'python fetch_catalog.py.'.
