### PR TITLE
Fix composer when llm_description does not exist

### DIFF
--- a/stylus/composer/composer.py
+++ b/stylus/composer/composer.py
@@ -166,7 +166,7 @@ def generate_adapters_catalog(adapters: List[AdapterInfo]):
         if adapter.llm_description:
             adapter_description = adapter.llm_description
         else:
-            adapter.description = adapter.description[:1000] if adapter.description else 'None'
+            adapter_description = adapter.description[:1000] if adapter.description else 'None'
         
         adapter_catalog_str += ADAPTER_CATALOG.format(adapter_idx=idx,
                                                         adapter_title=adapter.title,


### PR DESCRIPTION
What does this PR do?
-----
This PR fixes an issue where an error occurred when the adapter's llm_description was missing (UnboundLocalError: local variable 'adapter_description' referenced before assignment). Essentially, it corrects the incorrect variable name from 'adapter.description' to 'adapter_description'.
